### PR TITLE
frozen  padding token embedding vector.

### DIFF
--- a/mlx_esm/model.py
+++ b/mlx_esm/model.py
@@ -182,8 +182,8 @@ class MultiHeadAttention(nn.Module):
     queries = queries * scale
 
     kv = self.kv_proj(mx.concatenate([keys, values]))
-    keys = kv[:self.vdims, :]
-    values = kv[self.vdims, :]
+    keys = kv[:, :self.vdims, :]
+    values = kv[:, self.vdims, :]
 
     _, S, _ = keys.shape
     K = C // H


### PR DESCRIPTION
the key startwiths "_" will be filtered out of the trainable parameters by `valid_parameter_filter` in `mlx.nn.base.Module`. so the padding zeros will be frozen,  which concatenated into _weight.